### PR TITLE
fix: handle fetch errors and provide URL fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@skyra/start-banner": "1.0.0",
 		"colorette": "^2.0.16",
 		"discord-api-types": "^0.32.1",
+		"ix": "^4.5.2",
 		"tslib": "^2.4.0"
 	},
 	"devDependencies": {

--- a/src/lib/structures/AnimeCommand.ts
+++ b/src/lib/structures/AnimeCommand.ts
@@ -1,12 +1,12 @@
 import { BrandingColors } from '#lib/common/constants';
 import { LanguageKeys } from '#lib/i18n/LanguageKeys';
 import { UnsafeEmbedBuilder, userMention } from '@discordjs/builders';
-import { err, fromAsync, ok, Result } from '@sapphire/result';
+import { err, fromAsync, ok, type Result } from '@sapphire/result';
 import { envParseString } from '@skyra/env-utilities';
 import { Command, TransformedArguments } from '@skyra/http-framework';
 import { resolveKey, resolveUserKey, type TypedT } from '@skyra/http-framework-i18n';
 import { APIApplicationCommandInteraction, MessageFlags } from 'discord-api-types/v10';
-import { elementAt } from 'ix/iterable/elementat';
+import { elementAt } from 'ix/iterable/elementat.js';
 import { platform, release } from 'node:os';
 import { setTimeout } from 'node:timers';
 

--- a/src/lib/structures/AnimeCommand.ts
+++ b/src/lib/structures/AnimeCommand.ts
@@ -1,15 +1,18 @@
 import { BrandingColors } from '#lib/common/constants';
 import { LanguageKeys } from '#lib/i18n/LanguageKeys';
 import { UnsafeEmbedBuilder, userMention } from '@discordjs/builders';
-import { err, ok } from '@sapphire/result';
+import { err, fromAsync, ok, Result } from '@sapphire/result';
 import { envParseString } from '@skyra/env-utilities';
 import { Command, TransformedArguments } from '@skyra/http-framework';
 import { resolveKey, resolveUserKey, type TypedT } from '@skyra/http-framework-i18n';
 import { APIApplicationCommandInteraction, MessageFlags } from 'discord-api-types/v10';
+import { elementAt } from 'ix/iterable/elementat';
 import { platform, release } from 'node:os';
+import { setTimeout } from 'node:timers';
 
 export class AnimeCommand extends Command {
 	private readonly type: string;
+	private readonly cache = new Set<string>();
 
 	public constructor(context: Command.Context, options: AnimeCommand.Options) {
 		super(context, options);
@@ -25,13 +28,13 @@ export class AnimeCommand extends Command {
 		return result.success ? this.handleSuccess(interaction, result.value, args) : this.handleError(interaction, result.error);
 	}
 
-	private handleSuccess(interaction: Command.Interaction, result: AnimeCommandFetchResult, args: AnimeCommandArgs) {
+	private handleSuccess(interaction: Command.Interaction, url: string, args: AnimeCommandArgs) {
 		const content = args.user ? userMention(args.user.user.id) : undefined;
 		const embed = new UnsafeEmbedBuilder()
 			.setTitle('→')
-			.setURL(result.url)
+			.setURL(url)
 			.setColor(BrandingColors.Primary)
-			.setImage(result.url)
+			.setImage(url)
 			.setFooter({ text: resolveKey(interaction, LanguageKeys.Commands.Anime.PoweredByWeebSh) });
 		return this.message({ content, embeds: [embed.toJSON()] });
 	}
@@ -41,16 +44,40 @@ export class AnimeCommand extends Command {
 		return this.message({ content, flags: MessageFlags.Ephemeral });
 	}
 
-	private async get(url: URL) {
-		const result = await fetch(url.href, { headers: AnimeCommand.headers });
-		if (result.ok) return ok((await result.json()) as AnimeCommandFetchResult);
+	private async get(url: URL): Promise<Result<string, TypedT>> {
+		// We will abort requests that take longer than 2 seconds, to be safe with the 3 second limit:
+		const abort = new AbortController();
+		const timer = setTimeout(() => abort.abort('TimeoutError'), 2000);
 
-		// If we received a 5XX code error, warn the user about the service's unavailability.
-		if (result.status >= 500) return err(LanguageKeys.Commands.Anime.UnavailableError);
+		const result = await fromAsync(fetch(url.href, { headers: AnimeCommand.headers, signal: abort.signal }));
+		clearTimeout(timer);
 
-		// If otherwise we got an 4XX error code, warn the user about unexpected error.
-		console.error(`Unexpected error in ${this.name}: [${result.status}] ${await result.text()}`);
-		return err(LanguageKeys.Commands.Anime.UnexpectedError);
+		// Handle cases in which we have a Response:
+		if (result.success) {
+			const response = result.value;
+
+			// If 2XX, deserialize the data, cache the URL, and return it:
+			if (response.ok) {
+				const data = (await response.json()) as AnimeCommandFetchResult;
+				this.cache.add(data.url);
+				return ok(data.url);
+			}
+
+			// If we got an 4XX error code, warn the error:
+			if (response.status < 500) {
+				console.error(`Unexpected error in ${this.name}: [${response.status}] ${await response.text()}`);
+			}
+		}
+
+		if (this.cache.size === 0) {
+			const key =
+				result.success && result.value.status >= 500
+					? LanguageKeys.Commands.Anime.UnavailableError
+					: LanguageKeys.Commands.Anime.UnexpectedError;
+			return err(key);
+		}
+
+		return ok(elementAt(this.cache.values(), Math.floor(Math.random() * this.cache.size))!);
 	}
 
 	private static readonly headers = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,6 +553,7 @@ __metadata:
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.0.0
     husky: ^8.0.1
+    ix: ^4.5.2
     lint-staged: ^12.4.1
     prettier: ^2.6.2
     pretty-quick: ^3.1.3
@@ -635,6 +636,13 @@ __metadata:
   version: 17.0.35
   resolution: "@types/node@npm:17.0.35"
   checksum: 7a24946ae7fd20267ed92466384f594e448bfb151081158d565cc635d406ecb29ea8fb85fcd2a1f71efccf26fb5bd3c6f509bde56077eb8b832b847a6664bc62
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^13.7.4":
+  version: 13.13.52
+  resolution: "@types/node@npm:13.13.52"
+  checksum: 8f1afff497ebeba209e2dc340d823284e087a47632afe99a7daa30eaff80893e520f222ad400cd1f2d3b8288e93cf3eaded52a8e64eaefb8aacfe6c35de98f42
   languageName: node
   linkType: hard
 
@@ -2512,6 +2520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ix@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "ix@npm:4.5.2"
+  dependencies:
+    "@types/node": ^13.7.4
+    tslib: ^2.3.0
+  checksum: 0249ae35eee3f40c4bb9f9e3244f82071ef2b86a374cd4407b16b02f3aaa0bca00302c7a9c3bdb1686e3c901bfec3e8a770df7f7601998dbf2f59a0151e5a4b5
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -3946,7 +3964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113


### PR DESCRIPTION
If `fetch()` threw due to an unknown error, the method would throw an error (as opposed to returning a Result), which would result on an undesirable error in the user's side.

If weeb.sh's API is down or experiencing an outage, Nekokai would fail to reply. With this patch, Nekokai will wait for 2 seconds before aborting the request and reply with a previously-received image. Best case scenario, `cdn.weeb.sh` will always work, and if not, it'll still be cached on Discord's side, as it's a very used API.
